### PR TITLE
Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: python
+
 sudo: false
+
 python:
 - '2.7'
+- '3.5'
+- '3.6'
+- '3.7'
+
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh
-  -O miniconda.sh; fi
+- wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r
@@ -13,24 +17,25 @@ install:
 - conda update -q conda
 - conda info -a
 - |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables toolz psutil
+  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
 - source activate test-environment
-- pip install orca openmatrix zbox
-- pip install activitysim
 # - pip install https://github.com/ActivitySim/activitysim/zipball/dev/
 - pip install pytest pytest-cov coveralls pycodestyle
-- pip install sphinx numpydoc sphinx_rtd_theme
 - pip install .
 - pip freeze
+
 script:
 - pycodestyle bca4abm
 - py.test --cov bca4abm --cov-report term-missing
+
 after_success:
 - coveralls
 - bin/build_docs.sh
+
 notifications:
   slack:
     secure: ssVfG9qhvZ3BkLCypS2zgCu0qE5z0shSp4WTBXft+Ra/t6p1UPfQP3x1cZt41K7Qd1biqlfhWgTOgC82DZpTjg98QkSZTNH0UEbo/5wnBUFrRxxa5U59GP4lQ48wFFYe+BlPPKY4dnw9UOCbpRM82ZXMQcBa0/WPS/ZFMP0clHluioPBXpQMsUmsv6W9LLRVuk+gshdmu1ASzIUw4UZK/fZP4pgtatonFzIVsHXeqWZueJBkUTAW3jc9BB9z9KYaP0EHwg6DxIt8kjmB3E4cQVhEolDIMf1DuC8O5tx+xC/GZRBFg4gBtYaqBulNuCUkkA1krFjN2H8LBZCmxCVx1o36DsEWfgQJxqNQyscxT7s+SGdmb5xNHhZZ56VaS7mxdE9cJmfAUpiBZbxL+WrLkzMuJUHZuZSJ8gyyp4UXYcPLqVOKDraAcH2xXJq5NU7J9ZcRTbhEsEoiyxG0WOlwjgO7s0lNYqJyJo39B6jP2x1ld05ydXU+xOcIVVatIfS/arozXodgrhV7kZP2xMVXGJlWy4I+11EBbGjrhvoFl82gHdUjALXoj8sMbz+JjT9t83ZWZojgQQV7LdPQbjN0Nq3MBTzL80SGiGZUYoaDU0BO5M0vj+Tw6jtYRngue4za2QLn/udainmkuJ09T7tDifJ7FXYgpdpuniHJPKKatvw=
+
 env:
   global:
      # GH_TOKEN RSGInc/bca4abm public_repo token

--- a/bca4abm/__init__.py
+++ b/bca4abm/__init__.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 # bca4abm
 # Copyright (C) 2016 RSG Inc
 # See full license in LICENSE.txt.
 
-import defaults
-import tables
-import processors
+from . import defaults
+from . import tables
+from . import processors
 
 __version__ = version = '0.1dev'

--- a/bca4abm/processors/__init__.py
+++ b/bca4abm/processors/__init__.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 # bca4abm
 # Copyright (C) 2016 RSG Inc
 # See full license in LICENSE.txt.
 
-import initialize
-import aggregate_trips
-import link
-import abm
-import four_step
+from . import initialize
+from . import aggregate_trips
+from . import link
+from . import abm
+from . import four_step

--- a/bca4abm/processors/abm/__init__.py
+++ b/bca4abm/processors/abm/__init__.py
@@ -1,6 +1,7 @@
-import person_trips
-import demographics
-import auto_ownership
-import physical_activity
+from __future__ import absolute_import
+from . import person_trips
+from . import demographics
+from . import auto_ownership
+from . import physical_activity
 
-import abm_results
+from . import abm_results

--- a/bca4abm/processors/abm/physical_activity.py
+++ b/bca4abm/processors/abm/physical_activity.py
@@ -109,8 +109,9 @@ def physical_activity_processor(
 
     trip_trace_rows = trace_hh_id and trips_df.household_id == trace_hh_id
 
-    rows_per_chunk = physical_activity_rpc(chunk_size, trips_df, persons_df,
-                                           physical_activity_trip_spec, trace_label)
+    rows_per_chunk, effective_chunk_size = \
+        physical_activity_rpc(chunk_size, trips_df, persons_df,
+                              physical_activity_trip_spec, trace_label)
 
     logger.info("physical_activity_processor chunk_size %s rows_per_chunk %s" %
                 (chunk_size, rows_per_chunk))
@@ -179,9 +180,10 @@ def physical_activity_processor(
         result_list.append(coc_summary)
 
         chunk_trace_label = 'trace_label chunk_%s' % i
-        cum_size = chunk.log_df_size(chunk_trace_label, 'trips_chunk', trips_chunk, cum_size=None)
-        cum_size = chunk.log_df_size(chunk_trace_label, 'persons_chunk', persons_chunk, cum_size)
-        chunk.log_chunk_size(chunk_trace_label, cum_size)
+        chunk.log_open(chunk_trace_label, chunk_size, effective_chunk_size)
+        chunk.log_df(chunk_trace_label, 'trips_chunk', trips_chunk)
+        chunk.log_df(chunk_trace_label, 'persons_chunk', persons_chunk)
+        chunk.log_close(chunk_trace_label)
 
     if len(result_list) > 1:
 

--- a/bca4abm/processors/aggregate_trips.py
+++ b/bca4abm/processors/aggregate_trips.py
@@ -43,7 +43,7 @@ def read_aggregate_trips_manifest(data_dir, model_settings):
     column_map = "aggregate_trips_manifest_column_map"
     if column_map in model_settings:
         manifest.rename(columns=model_settings[column_map], inplace=True)
-        assert not missing_columns(manifest, model_settings[column_map].values())
+        assert not missing_columns(manifest, list(model_settings[column_map].values()))
 
     return manifest
 

--- a/bca4abm/processors/four_step/__init__.py
+++ b/bca4abm/processors/four_step/__init__.py
@@ -1,3 +1,4 @@
-import aggregate_demographics
-import aggregate_zone
-import aggregate_od
+from __future__ import absolute_import
+from . import aggregate_demographics
+from . import aggregate_zone
+from . import aggregate_od

--- a/bca4abm/processors/link.py
+++ b/bca4abm/processors/link.py
@@ -49,7 +49,7 @@ def read_csv_file(data_dir, file_name, column_map=None):
     fpath = os.path.join(data_dir, file_name)
 
     if column_map:
-        usecols = column_map.keys()
+        usecols = list(column_map.keys())
         # print "read_bca_table usecols: ", usecols
         # FIXME - should we allow comment lines?
         df = bca.read_csv_or_tsv(fpath, header=0, usecols=usecols)
@@ -76,7 +76,7 @@ def add_tables_to_locals(data_dir, model_settings, locals_dict):
     if tables_tag in model_settings:
 
         file_list = model_settings.get(tables_tag)
-        for var_name, filename in file_list.iteritems():
+        for var_name, filename in list(file_list.items()):
 
             # print "add_tables_to_locals %s = %s" % (var_name, filename)
 
@@ -109,7 +109,7 @@ def eval_link_spec(link_spec, link_file_names, data_dir,
         link_data_subdir = 'base-data' if scenario == 'base' else 'build-data'
 
         df_list = []
-        for suffix, link_file_name in link_file_names.iteritems():
+        for suffix, link_file_name in list(link_file_names.items()):
 
             df = read_csv_file(data_dir=os.path.join(data_dir, link_data_subdir),
                                file_name=link_file_name,
@@ -150,6 +150,10 @@ def eval_link_spec(link_spec, link_file_names, data_dir,
         results[scenario] = summary
 
         if trace_results is not None:
+            # FIXME: manually setting df.index.name to prevent
+            # activitysim.tracing.write_df_csv() from attempting to reset the index.
+            # write_df_csv() should be able to handle a multi-index dataframe.
+            trace_results.index.name = trace_results.index.names[0]
             tracing.write_csv(trace_results,
                               file_name="%s_results_%s" % (trace_tag, scenario),
                               index_label='index',

--- a/bca4abm/tables/__init__.py
+++ b/bca4abm/tables/__init__.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 # bca4abm
 # Copyright (C) 2016 RSG Inc
 # See full license in LICENSE.txt.
 
-import trips
-import households
-import persons
-import benefits
-import zones
+from . import trips
+from . import households
+from . import persons
+from . import benefits
+from . import zones

--- a/bca4abm/tables/households.py
+++ b/bca4abm/tables/households.py
@@ -1,6 +1,7 @@
 # bca4abm
 # See full license in LICENSE.txt.
 
+from builtins import range
 import logging
 
 import os.path
@@ -37,7 +38,7 @@ def households(data_dir, settings):
 
     # - assign chunk_ids
     assert 'chunk_id' not in households.columns
-    households['chunk_id'] = pd.Series(range(len(households)), households.index)
+    households['chunk_id'] = pd.Series(list(range(len(households))), households.index)
 
     return households
 

--- a/bca4abm/tables/zones.py
+++ b/bca4abm/tables/zones.py
@@ -1,6 +1,7 @@
 # bca4abm
 # See full license in LICENSE.txt.
 
+from builtins import range
 import logging
 
 import os.path
@@ -30,6 +31,7 @@ def read_csv_file(data_dir, file_name):
 def read_zone_indexed_csv_file(data_dir, file_name, zone_aliases, zone_ids_index):
 
     fpath = os.path.join(data_dir, file_name)
+    logger.info("read zone indexed csv file: " + fpath)
 
     df = bca.read_csv_or_tsv(fpath, header=0, comment='#').rename(columns=zone_aliases)
 
@@ -46,7 +48,7 @@ def read_zone_indexed_csv_file(data_dir, file_name, zone_aliases, zone_ids_index
         df.index = df.index + 1
 
         if 'zone' in df:
-            assert (df.index.values == range(1, len(df) + 1)).all()
+            assert (df.index.values == list(range(1, len(df) + 1))).all()
 
     df.index.name = 'ZONE'
 
@@ -90,7 +92,7 @@ def check_zone_index(df, zone_ids):
     if zone_ids is not None:
         expected_index = zone_ids.values
     else:
-        expected_index = range(1, len(df) + 1)
+        expected_index = list(range(1, len(df) + 1))
     assert (df.index.values == expected_index).all()
     assert df.index.name == 'ZONE'
 

--- a/bca4abm/tests/configs/logging.yaml
+++ b/bca4abm/tests/configs/logging.yaml
@@ -1,6 +1,6 @@
 # Config for logging
 # ------------------
-# See http://docs.python.org/2.7/library/logging.config.html#configuration-dictionary-schema
+# See http://docs.python.org/3.7/library/logging.config.html#configuration-dictionary-schema
 
 logging:
   version: 1
@@ -9,18 +9,18 @@ logging:
 
   # Configuring the default (root) logger is highly recommended
   root:
-    level: !!python/name:logging.NOTSET
+    level: NOTSET
     handlers: [console]
 
   loggers:
 
     bca4abm:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     orca:
-      level: !!python/name:logging.INFO
+      level: INFO
       handlers: [console, logfile]
       propagate: false
 
@@ -28,26 +28,26 @@ logging:
 
     logfile:
       class: logging.FileHandler
-      filename: !!python/object/apply:bca4abm.tracing.log_file_path ['bca.log']
+      filename: !!python/object/apply:bca4abm.config.log_file_path ['bca.log']
       mode: w
       formatter: fileFormatter
-      level: !!python/name:logging.NOTSET
+      level: NOTSET
 
     console:
       class: logging.StreamHandler
       stream: ext://sys.stdout
       formatter: simpleFormatter
-      #level: !!python/name:logging.NOTSET
-      level: !!python/name:logging.WARN
+      #level: NOTSET
+      level: WARN
 
   formatters:
 
     simpleFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
 
     fileFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'

--- a/bca4abm/tests/test_4step/configs/logging.yaml
+++ b/bca4abm/tests/test_4step/configs/logging.yaml
@@ -1,6 +1,6 @@
 # Config for logging
 # ------------------
-# See http://docs.python.org/2.7/library/logging.config.html#configuration-dictionary-schema
+# See http://docs.python.org/3.7/library/logging.config.html#configuration-dictionary-schema
 
 logging:
   version: 1
@@ -9,23 +9,23 @@ logging:
 
   # Configuring the default (root) logger is highly recommended
   root:
-    level: !!python/name:logging.NOTSET
+    level: NOTSET
     handlers: [console, logfile]
 
   loggers:
 
     bca4abm:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     activitysim:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     orca:
-      level: !!python/name:logging.INFO
+      level: INFO
       handlers: [console, logfile]
       propagate: false
 
@@ -33,28 +33,27 @@ logging:
 
     logfile:
       class: logging.FileHandler
-      filename: !!python/object/apply:activitysim.core.tracing.log_file_path ['bca.log']
+      filename: !!python/object/apply:activitysim.core.config.log_file_path ['bca.log']
       mode: w
       formatter: fileFormatter
-      level: !!python/name:logging.NOTSET
-      #level: !!python/name:logging.INFO
+      level: NOTSET
+      #level: INFO
 
     console:
       class: logging.StreamHandler
       stream: ext://sys.stdout
       formatter: simpleFormatter
-      #level: !!python/name:logging.NOTSET
-      level: !!python/name:logging.INFO
+      #level: NOTSET
+      level: INFO
 
   formatters:
 
     simpleFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
 
     fileFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
-

--- a/bca4abm/tests/test_4step/test_4step_processors.py
+++ b/bca4abm/tests/test_4step/test_4step_processors.py
@@ -3,7 +3,6 @@ import os.path
 import logging
 import numpy.testing as npt
 import pandas as pd
-import orca
 
 import pytest
 import yaml
@@ -18,7 +17,7 @@ from bca4abm import bca4abm as bca
 
 
 def teardown_function(func):
-    orca.clear_cache()
+    inject.clear_cache()
     inject.reinject_decorated_tables()
 
 
@@ -35,13 +34,13 @@ def close_handlers():
 def inject_settings(chunk_size=None, trace_hh_id=None, trace_od=None):
 
     configs_dir = os.path.join(os.path.dirname(__file__), 'configs')
-    orca.add_injectable("configs_dir", configs_dir)
+    inject.add_injectable("configs_dir", configs_dir)
 
     output_dir = os.path.join(os.path.dirname(__file__), 'output')
-    orca.add_injectable("output_dir", output_dir)
+    inject.add_injectable("output_dir", output_dir)
 
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
-    orca.add_injectable("data_dir", data_dir)
+    inject.add_injectable("data_dir", data_dir)
 
     with open(os.path.join(configs_dir, 'settings.yaml')) as f:
         settings = yaml.load(f)
@@ -52,7 +51,7 @@ def inject_settings(chunk_size=None, trace_hh_id=None, trace_od=None):
         if trace_od is not None:
             settings['trace_od'] = trace_od
 
-    orca.add_injectable("settings", settings)
+    inject.add_injectable("settings", settings)
 
     return settings
 
@@ -64,12 +63,27 @@ def test_run_4step():
         trace_hh_id=None,
         trace_od=None)
 
-    orca.clear_cache()
+    inject.clear_cache()
 
     tracing.config_logger()
 
     MODELS = settings['models']
 
     pipeline.run(models=MODELS, resume_after=None)
+
+    pipeline.close_pipeline()
+
+
+def test_zero_chunk_size():
+
+    settings = inject_settings(chunk_size=0)
+
+    inject.clear_cache()
+
+    tracing.config_logger()
+
+    MODELS = settings['models']
+
+    pipeline.run(models=MODELS, resume_after='aggregate_od_processor')
 
     pipeline.close_pipeline()

--- a/bca4abm/tests/test_4step/test_4step_tables.py
+++ b/bca4abm/tests/test_4step/test_4step_tables.py
@@ -2,16 +2,17 @@ import os.path
 
 import numpy.testing as npt
 import pandas as pd
-import orca
 import pandas.util.testing as pdt
 import pytest
 
+from activitysim.core import inject
 
-# orca injectables complicate matters because the decorators are executed at module load time
+
+# inject injectables complicate matters because the decorators are executed at module load time
 # and since py.test collects modules and loads them at the start of a run
 # if a test method does something that has a lasting side-effect, then that side effect
 # will carry over not just to subsequent test functions, but to subsequently called modules
-# for instance, columns added with add_column will remain attached to orca tables
+# for instance, columns added with add_column will remain attached to inject tables
 # pytest-xdist allows us to run py.test with the --boxed option which runs every function
 # with a brand new python interpreter
 # py.test --boxed --cov bca4abm
@@ -26,23 +27,23 @@ from bca4abm.util.misc import expect_columns, missing_columns, extra_columns, ma
 def inject_default_directories(request):
 
     parent_dir = os.path.dirname(__file__)
-    orca.add_injectable("configs_dir", os.path.join(parent_dir, 'configs'))
-    orca.add_injectable("data_dir", os.path.join(parent_dir, 'data'))
-    orca.add_injectable("output_dir", os.path.join(parent_dir, 'output'))
+    inject.add_injectable("configs_dir", os.path.join(parent_dir, 'configs'))
+    inject.add_injectable("data_dir", os.path.join(parent_dir, 'data'))
+    inject.add_injectable("output_dir", os.path.join(parent_dir, 'output'))
 
-    request.addfinalizer(orca.clear_cache)
+    request.addfinalizer(inject.clear_cache)
 
 
 def test_read_zone_hh_table():
 
-    zones = orca.get_table('zone_hhs').to_frame()
+    zones = inject.get_table('zone_hhs').to_frame()
 
     assert zones.shape[0] == 25
 
 
 def test_read_zones_table():
 
-    zones = orca.get_table('zones').to_frame()
+    zones = inject.get_table('zones').to_frame()
 
     # number of zones in sample data
     assert zones.shape[0] == 25

--- a/bca4abm/tests/test_abm/configs/logging.yaml
+++ b/bca4abm/tests/test_abm/configs/logging.yaml
@@ -1,6 +1,6 @@
 # Config for logging
 # ------------------
-# See http://docs.python.org/2.7/library/logging.config.html#configuration-dictionary-schema
+# See http://docs.python.org/3.7/library/logging.config.html#configuration-dictionary-schema
 
 logging:
   version: 1
@@ -9,23 +9,23 @@ logging:
 
   # Configuring the default (root) logger is highly recommended
   root:
-    level: !!python/name:logging.NOTSET
+    level: NOTSET
     handlers: [console, logfile]
 
   loggers:
 
     bca4abm:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     activitysim:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     orca:
-      level: !!python/name:logging.INFO
+      level: INFO
       handlers: [console, logfile]
       propagate: false
 
@@ -33,26 +33,25 @@ logging:
 
     logfile:
       class: logging.FileHandler
-      filename: !!python/object/apply:activitysim.core.tracing.log_file_path ['asim.log']
+      filename: !!python/object/apply:activitysim.core.config.log_file_path ['activitysim.log']
       mode: w
       formatter: fileFormatter
-      level: !!python/name:logging.NOTSET
+      level: NOTSET
 
     console:
       class: logging.StreamHandler
       stream: ext://sys.stdout
       formatter: simpleFormatter
-      level: !!python/name:logging.NOTSET
+      level: NOTSET
 
   formatters:
 
     simpleFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
 
     fileFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
-

--- a/bca4abm/tests/test_abm/test_abm_processors.py
+++ b/bca4abm/tests/test_abm/test_abm_processors.py
@@ -3,7 +3,6 @@ import os.path
 import logging
 import numpy.testing as npt
 import pandas as pd
-import orca
 
 import pytest
 import yaml
@@ -18,7 +17,7 @@ from bca4abm import bca4abm as bca
 
 
 def teardown_function(func):
-    orca.clear_cache()
+    inject.clear_cache()
     inject.reinject_decorated_tables()
 
 
@@ -35,13 +34,13 @@ def close_handlers():
 def inject_settings(chunk_size=None, trace_hh_id=None, trace_od=None):
 
     configs_dir = os.path.join(os.path.dirname(__file__), 'configs')
-    orca.add_injectable("configs_dir", configs_dir)
+    inject.add_injectable("configs_dir", configs_dir)
 
     output_dir = os.path.join(os.path.dirname(__file__), 'output')
-    orca.add_injectable("output_dir", output_dir)
+    inject.add_injectable("output_dir", output_dir)
 
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
-    orca.add_injectable("data_dir", data_dir)
+    inject.add_injectable("data_dir", data_dir)
 
     with open(os.path.join(configs_dir, 'settings.yaml')) as f:
         settings = yaml.load(f)
@@ -52,7 +51,7 @@ def inject_settings(chunk_size=None, trace_hh_id=None, trace_od=None):
         if trace_od is not None:
             settings['trace_od'] = trace_od
 
-    orca.add_injectable("settings", settings)
+    inject.add_injectable("settings", settings)
 
     return settings
 
@@ -64,7 +63,7 @@ def run_abm(models, resume_after=None, chunk_size=None, trace_hh_id=None, trace_
         trace_hh_id=trace_hh_id,
         trace_od=trace_od)
 
-    orca.clear_cache()
+    inject.clear_cache()
 
     tracing.config_logger()
 

--- a/bca4abm/tests/test_abm/test_abm_tables.py
+++ b/bca4abm/tests/test_abm/test_abm_tables.py
@@ -5,16 +5,15 @@ import pandas as pd
 import pandas.util.testing as pdt
 import pytest
 
-import orca
 from activitysim.core import inject
 from activitysim.core import config
 
 
-# orca injectables complicate matters because the decorators are executed at module load time
+# inject injectables complicate matters because the decorators are executed at module load time
 # and since py.test collects modules and loads them at the start of a run
 # if a test method does something that has a lasting side-effect, then that side effect
 # will carry over not just to subsequent test functions, but to subsequently called modules
-# for instance, columns added with add_column will remain attached to orca tables
+# for instance, columns added with add_column will remain attached to inject tables
 # pytest-xdist allows us to run py.test with the --boxed option which runs every function
 # with a brand new python interpreter
 # py.test --boxed --cov bca4abm
@@ -33,7 +32,7 @@ def inject_default_directories(request):
     inject.add_injectable("data_dir", os.path.join(parent_dir, 'data'))
     inject.add_injectable("output_dir", os.path.join(parent_dir, 'output'))
 
-    request.addfinalizer(orca.clear_cache)
+    request.addfinalizer(inject.clear_cache)
 
 
 def test_read_persons_table():
@@ -44,7 +43,7 @@ def test_read_persons_table():
     # expect all of and only the columns specified by persons_column_map values
     persons = inject.get_table('persons').to_frame()
     assert expect_columns(persons,
-                          table_settings['persons_column_map'].values())
+                          list(table_settings['persons_column_map'].values()))
 
     assert persons.shape[0] == 27
 
@@ -55,10 +54,10 @@ def test_read_households_table():
 
     households = inject.get_table('households').to_frame()
     assert not missing_columns(households,
-                               table_settings['base_households_column_map'].values())
+                               list(table_settings['base_households_column_map'].values()))
 
     assert not missing_columns(households,
-                               table_settings['build_households_column_map'].values())
+                               list(table_settings['build_households_column_map'].values()))
 
     assert households.shape[0] == 9
 

--- a/bca4abm/tests/test_bca4abm.py
+++ b/bca4abm/tests/test_bca4abm.py
@@ -2,7 +2,7 @@ import os.path
 
 import numpy.testing as npt
 import pandas as pd
-import orca
+from activitysim.core import inject
 
 import pandas.util.testing as pdt
 import pytest
@@ -17,11 +17,11 @@ from bca4abm.util.misc import expect_columns, missing_columns, extra_columns
 def inject_default_directories(request):
 
     parent_dir = os.path.dirname(__file__)
-    orca.add_injectable("configs_dir", os.path.join(parent_dir, 'configs'))
-    orca.add_injectable("data_dir", os.path.join(parent_dir, 'data'))
-    orca.add_injectable("output_dir", os.path.join(parent_dir, 'output'))
+    inject.add_injectable("configs_dir", os.path.join(parent_dir, 'configs'))
+    inject.add_injectable("data_dir", os.path.join(parent_dir, 'data'))
+    inject.add_injectable("output_dir", os.path.join(parent_dir, 'output'))
 
-    request.addfinalizer(orca.clear_cache)
+    request.addfinalizer(inject.clear_cache)
 
 
 def test_misc():
@@ -40,7 +40,7 @@ def test_misc():
 def test_read_csv_table():
 
     settings = {'persons': 'persons.csv'}
-    data_dir = orca.eval_variable('data_dir')
+    data_dir = inject.get_injectable('data_dir')
 
     df = bca.read_csv_table(data_dir, settings, table_name="persons",  index_col='person_id')
 
@@ -50,7 +50,7 @@ def test_read_csv_table():
 def test_read_csv_table_with_tsv():
 
     settings = {'persons': 'persons.tsv'}
-    data_dir = orca.eval_variable('data_dir')
+    data_dir = inject.get_injectable('data_dir')
 
     df = bca.read_csv_table(data_dir, settings, table_name="persons",  index_col='person_id')
 
@@ -60,7 +60,7 @@ def test_read_csv_table_with_tsv():
 def test_read_csv_table_with_txt():
 
     settings = {'persons': 'persons.txt'}
-    data_dir = orca.eval_variable('data_dir')
+    data_dir = inject.get_injectable('data_dir')
 
     df = bca.read_csv_table(data_dir, settings, table_name="persons",  index_col='person_id')
 

--- a/bca4abm/util/misc.py
+++ b/bca4abm/util/misc.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
 # bca4abm
 # See full license in LICENSE.txt.
 
+from builtins import zip
 import logging
 
 import pandas as pd
@@ -93,10 +95,10 @@ def expect_columns(table, expected_column_names):
     extra_column_names = extra_columns(table, expected_column_names)
 
     for c in missing_column_names:
-        print "expect_columns MISSING expected column %s" % c
+        print("expect_columns MISSING expected column %s" % c)
 
     for c in extra_column_names:
-        print "expect_columns FOUND unexpected column %s" % c
+        print("expect_columns FOUND unexpected column %s" % c)
 
     if missing_column_names or extra_column_names:
         missing = ", ".join(missing_column_names)
@@ -125,7 +127,7 @@ def add_aggregate_results(results, spec, source='', zonal=True):
 
     # target can appear more than once, so this ensures we only use the final one
     seen = set()
-    for e in reversed(zip(spec.target, spec.silos, spec.description)):
+    for e in reversed(list(zip(spec.target, spec.silos, spec.description))):
         target, silos, description = e
 
         # nothing to do if we already handled a later occurrence of this same target

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -2,28 +2,22 @@
 Getting Started
 ===============
 
-bca4abm includes activity-based model and four-step trip-based model :ref:`examples` to help get you started.  
+bca4abm includes activity-based model and four-step trip-based model :ref:`examples` to help get you started.
 
 Installation
 ------------
 
-* Install `Anaconda Python 2.7 <https://www.continuum.io/downloads>`_, which includes a number of required Python packages.
+* Install `Anaconda 64bit Python 3 <https://www.anaconda.com/distribution/>`__, which includes a number of required Python packages.
 * Create and activate an Anaconda environment (i.e. a Python install just for this project).
 
-:: 
+::
 
-  conda create -n bca4abmtest python=2.7
+  conda create -n bca4abmtest python=3.7
   activate bca4abmtest
-
-* Get and install other required libraries from the `Python Package Index <https://pypi.python.org/pypi>`_
-
-:: 
-
-  pip install orca toolz zbox openmatrix activitysim
 
 * Get and install the bca4abm package from `GitHub <https://github.com/RSGInc/bca4abm>`_
 
-:: 
+::
 
   pip install https://github.com/RSGInc/bca4abm/zipball/master
 
@@ -33,7 +27,7 @@ Running the Model
 
 * Activate the conda Python environment
 
-:: 
+::
 
   activate bca4abmtest
 
@@ -60,13 +54,13 @@ Expressions
 
 To help illustrate how the benefits calculator works, an example set of expressions for calculating zone benefits is below.  Each input is a zone data table with
 each row a zone and each column a zone attribute.  The example processes the
-base and build home-based-other productions by zone, as well as the base and build mode choice logsum, and calculates 
-an accessibility benefit measure.  The idea here is that improvements in multi-modal accessibility (i.e. the logsum) between the 
-based and build scenario results in increased accessibility or additional travel options.  The accessibility benefit is calculated 
+base and build home-based-other productions by zone, as well as the base and build mode choice logsum, and calculates
+an accessibility benefit measure.  The idea here is that improvements in multi-modal accessibility (i.e. the logsum) between the
+based and build scenario results in increased accessibility or additional travel options.  The accessibility benefit is calculated
 using the rule-of-half.  As a result, the calculation is half the difference in the productions
-times the difference in the logsums divided by utilities per minute for home-based-other trips times the value-of-time for 
+times the difference in the logsums divided by utilities per minute for home-based-other trips times the value-of-time for
 home-based-other trips times the annual discount rate times a daily to annual factor.  The result is monetized benefits for increases
-in accessibility by zone.  
+in accessibility by zone.
 
 +-------------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  Description                              | Target                 | Expression                                                                                                                                 |
@@ -76,7 +70,7 @@ in accessibility by zone.
 |  hbo productions in base scenario         |  base_prod_hbo         |  zones.base_hboprl + zones.base_hboprm + zones.base_hboprh                                                                                 |
 +-------------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  hbo productions in build scenario        |  build_prod_hbo        |  zones.build_hboprl + zones.build_hboprm + zones.build_hboprh                                                                              |
-+-------------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+ 
++-------------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  hbo logsum in base scenario              |  base_ls_hbo           |  zones.base_hbodcls                                                                                                                        |
 +-------------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  hbo logsum in build scenario             |  build_ls_hbo          |  zones.build_hbodcls                                                                                                                       |

--- a/docs/software.rst
+++ b/docs/software.rst
@@ -1,19 +1,19 @@
 
-Software Implementation 
+Software Implementation
 =======================
 
-This page describes the bca4abm software implementation and how to contribute.  
+This page describes the bca4abm software implementation and how to contribute.
 
-The implementation starts with 
+The implementation starts with
 the ActivitySim framework, which serves as the foundation for the software.  The framework, as briefly described
-below, includes features for data pipeline management, expression handling, testing, etc.  Built upon the 
+below, includes features for data pipeline management, expression handling, testing, etc.  Built upon the
 framework are additional core components for benefits calculation.
 
 ActivitySim Framework
 ---------------------
 
-bca4abm is implemented in the `ActivitySim <https://github.com/activitysim/activitysim>`__ 
-framework.  As summarized `here <https://activitysim.github.io/activitysim/#software-design>`__, 
+bca4abm is implemented in the `ActivitySim <https://github.com/activitysim/activitysim>`__
+framework.  As summarized `here <https://activitysim.github.io/activitysim/#software-design>`__,
 being implemented in the ActivitySim framework means:
 
 * Overall Design
@@ -21,32 +21,32 @@ being implemented in the ActivitySim framework means:
   * Implemented in Python, and makes heavy use of the vectorized backend C/C++ libraries in `pandas <http://pandas.pydata.org>`__ and `numpy <http://www.numpy.org>`__.
   * Vectorization instead of for loops when possible
   * Runs sub-models that solve Python expression files that operate on data tables
-  
+
 * Data Handling
 
   * Inputs are in CSV format, with the exception of settings
   * CSVs are read-in as pandas tables and stored in an intermediate HDF5 binary file that is used for data I/O throughout the model run
   * Key outputs are written to CSV files
-  
+
 * Key Data Structures
 
   * `pandas.DataFrame <http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html>`__ - A data table with rows and columns, similar to an R data frame, Excel worksheet, or database table
   * `pandas.Series <http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.html>`__ - a vector of data, a column in a DataFrame table or a 1D array
   * `numpy.array <https://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html>`__ - an N-dimensional array of items of the same type, such as a matrix
-  
+
 * Model Orchestrator
 
-  * `ORCA <https://github.com/UDST/orca>`__ is used for running the overall model system and for defining dynamic data tables, columns, and injectables (functions). ActivitySim wraps ORCA functionality to make a Data Pipeline tool, which allows for re-starting at any model step.  
-    
+  * `ORCA <https://github.com/UDST/orca>`__ is used for running the overall model system and for defining dynamic data tables, columns, and injectables (functions). ActivitySim wraps ORCA functionality to make a Data Pipeline tool, which allows for re-starting at any model step.
+
 * Expressions
 
-  * Model expressions are in CSV files and contain Python expressions, mainly pandas/numpy expression that operate on the input data tables. This helps to avoid modifying Python code when making changes to the model calculations. 
-    
+  * Model expressions are in CSV files and contain Python expressions, mainly pandas/numpy expression that operate on the input data tables. This helps to avoid modifying Python code when making changes to the model calculations.
+
 * `Code Documentation <https://activitysim.github.io/activitysim/development.html>`__
 
   * Python code according to `pycodestyle <https://pypi.python.org/pypi/pycodestyle>`__ style guide
   * Written in `reStructuredText <http://docutils.sourceforge.net/rst.html>`__ markup, built with `Sphinx <http://www.sphinx-doc.org/en/stable>`__ and docstrings written in `numpydoc <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`__
-    
+
 * `Testing <https://activitysim.github.io/activitysim/development.html>`__
 
   * A protected master branch that can only be written to after tests have passed
@@ -63,7 +63,7 @@ bca4abm
 
 .. automodule:: bca4abm.bca4abm
    :members:
-   
+
 aggregate_trips
 ^^^^^^^^^^^^^^^
 
@@ -75,7 +75,7 @@ link
 
 .. automodule:: bca4abm.processors.link
    :members:
-   
+
 ABM Processors
 --------------
 
@@ -86,19 +86,19 @@ abm_results
 
 .. automodule:: bca4abm.processors.abm.abm_results
    :members:
-   
+
 auto_ownership
 ^^^^^^^^^^^^^^
 
 .. automodule:: bca4abm.processors.abm.auto_ownership
    :members:
-   
+
 demographics
 ^^^^^^^^^^^^
 
 .. automodule:: bca4abm.processors.abm.demographics
    :members:
-   
+
 person_trips
 ^^^^^^^^^^^^
 
@@ -121,19 +121,19 @@ aggregate_demographics
 
 .. automodule:: bca4abm.processors.four_step.aggregate_demographics
    :members:
-   
+
 aggregate_zone
 ^^^^^^^^^^^^^^
 
 .. automodule:: bca4abm.processors.four_step.aggregate_zone
    :members:
-   
+
 aggregate_od
 ^^^^^^^^^^^^
 
 .. automodule:: bca4abm.processors.four_step.aggregate_od
    :members:
-   
+
 Contribution Guidelines
 -----------------------
 
@@ -144,3 +144,4 @@ Release Notes
 -------------
 
   * v0.4 - first release
+  * v0.5 - add Python 3.5+ support

--- a/example_4step/configs/logging.yaml
+++ b/example_4step/configs/logging.yaml
@@ -1,6 +1,6 @@
 # Config for logging
 # ------------------
-# See http://docs.python.org/2.7/library/logging.config.html#configuration-dictionary-schema
+# See https://docs.python.org/3.7/library/logging.config.html#configuration-dictionary-schema
 
 logging:
   version: 1
@@ -9,23 +9,23 @@ logging:
 
   # Configuring the default (root) logger is highly recommended
   root:
-    level: !!python/name:logging.NOTSET
+    level: NOTSET
     handlers: [console, logfile]
 
   loggers:
 
     bca4abm:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     activitysim:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     orca:
-      level: !!python/name:logging.INFO
+      level: INFO
       handlers: [console, logfile]
       propagate: false
 
@@ -33,28 +33,27 @@ logging:
 
     logfile:
       class: logging.FileHandler
-      filename: !!python/object/apply:activitysim.core.tracing.log_file_path ['bca.log']
+      filename: !!python/object/apply:activitysim.core.config.log_file_path ['bca.log']
       mode: w
       formatter: fileFormatter
-      level: !!python/name:logging.NOTSET
-      #level: !!python/name:logging.INFO
+      level: NOTSET
+      #level: INFO
 
     console:
       class: logging.StreamHandler
       stream: ext://sys.stdout
       formatter: simpleFormatter
-      level: !!python/name:logging.NOTSET
-      #level: !!python/name:logging.INFO
+      level: NOTSET
+      #level: INFO
 
   formatters:
 
     simpleFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
 
     fileFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
-

--- a/example_4step/run_bca.py
+++ b/example_4step/run_bca.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # bca4abm
 # Copyright (C) 2016 RSG Inc
 # See full license in LICENSE.txt.
@@ -31,14 +32,14 @@ parent_dir = os.path.dirname(__file__)
 handle_standard_args()
 
 tracing.config_logger()
-tracing.delete_csv_files(output_dir=inject.get_injectable('output_dir'))
+tracing.delete_csv_files()  # only modifies output_dir
 
 warnings.simplefilter("always")
 
 logging.captureWarnings(capture=True)
 
 old_settings = np.seterr(divide='raise', over='raise', invalid='raise', under='ignore')
-print "numpy.geterr: %s" % np.geterr()
+print("numpy.geterr: %s" % np.geterr())
 
 
 t0 = tracing.print_elapsed_time()
@@ -51,7 +52,7 @@ MODELS = setting('models')
 resume_after = setting('resume_after', None)
 
 if resume_after:
-    print "resume_after", resume_after
+    print("resume_after", resume_after)
 
 
 pipeline.run(models=MODELS, resume_after=resume_after)
@@ -60,4 +61,3 @@ pipeline.run(models=MODELS, resume_after=resume_after)
 pipeline.close_pipeline()
 
 t0 = tracing.print_elapsed_time("all models", t0)
-

--- a/example_abm/configs/logging.yaml
+++ b/example_abm/configs/logging.yaml
@@ -1,6 +1,6 @@
 # Config for logging
 # ------------------
-# See http://docs.python.org/2.7/library/logging.config.html#configuration-dictionary-schema
+# See http://docs.python.org/3.7/library/logging.config.html#configuration-dictionary-schema
 
 logging:
   version: 1
@@ -9,23 +9,23 @@ logging:
 
   # Configuring the default (root) logger is highly recommended
   root:
-    level: !!python/name:logging.NOTSET
+    level: NOTSET
     handlers: [console, logfile]
 
   loggers:
 
     bca4abm:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     activitysim:
-      level: !!python/name:logging.DEBUG
+      level: DEBUG
       handlers: [console, logfile]
       propagate: false
 
     orca:
-      level: !!python/name:logging.INFO
+      level: INFO
       handlers: [console, logfile]
       propagate: false
 
@@ -33,26 +33,25 @@ logging:
 
     logfile:
       class: logging.FileHandler
-      filename: !!python/object/apply:activitysim.core.tracing.log_file_path ['asim.log']
+      filename: !!python/object/apply:activitysim.core.config.log_file_path ['activitysim.log']
       mode: w
       formatter: fileFormatter
-      level: !!python/name:logging.NOTSET
+      level: NOTSET
 
     console:
       class: logging.StreamHandler
       stream: ext://sys.stdout
       formatter: simpleFormatter
-      level: !!python/name:logging.NOTSET
+      level: NOTSET
 
   formatters:
 
     simpleFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
 
     fileFormatter:
-      class: !!python/name:logging.Formatter
+      class: logging.Formatter
       format: '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
       datefmt: '%d/%m/%Y %H:%M:%S'
-

--- a/example_abm/run_bca.py
+++ b/example_abm/run_bca.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # bca4abm
 # Copyright (C) 2016 RSG Inc
 # See full license in LICENSE.txt.
@@ -30,14 +31,14 @@ parent_dir = os.path.dirname(__file__)
 handle_standard_args()
 
 tracing.config_logger()
-tracing.delete_csv_files(output_dir=inject.get_injectable('output_dir'))
+tracing.delete_csv_files()  # only modifies output_dir
 
 warnings.simplefilter("always")
 
 logging.captureWarnings(capture=True)
 
 old_settings = np.seterr(divide='raise', over='raise', invalid='raise', under='ignore')
-print "numpy.geterr: %s" % np.geterr()
+print("numpy.geterr: %s" % np.geterr())
 
 
 t0 = tracing.print_elapsed_time()
@@ -50,7 +51,7 @@ MODELS = setting('models')
 resume_after = setting('resume_after', None)
 
 if resume_after:
-    print "resume_after", resume_after
+    print("resume_after", resume_after)
 
 
 pipeline.run(models=MODELS, resume_after=resume_after)
@@ -59,5 +60,3 @@ pipeline.run(models=MODELS, resume_after=resume_after)
 pipeline.close_pipeline()
 
 t0 = tracing.print_elapsed_time("all models", t0)
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name="bca4abm",
-    version='0.4',
+    version='0.5',
     description='Benefit Calculations for Travel Models',
     author='contributing authors',
     author_email='ben.stabler@rsginc.com',
@@ -10,13 +10,14 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     include_package_data=True,
     install_requires=[
-        'numpy >= 1.8.0',
-        'openmatrix >= 0.2.2',
-        'pandas >= 0.23.0',
-        'pyyaml >= 3.0, <5.1',
-        'tables >= 3.1.0',
-        'toolz >= 0.7',
+        'numpy >= 1.16.1',
+        'openmatrix >= 0.3.4.1',
+        'pandas >= 0.24.1',
+        'pyyaml >= 5.1',
+        'tables >= 3.5.1',
+        'toolz >= 0.8.1',
         'zbox >= 1.2',
-        'activitysim == 0.7',
+        'activitysim >= 0.9.1',
+        'future >= 0.16.0'
     ]
 )


### PR DESCRIPTION
Support for Python 3, with Python 2.7 backwards compatibility provided by the `future` package.

This requires using the latest ActivitySim, and BCA needs some small module changes to accommodate. Injectables now use `activitysim.core.inject` instead of `orca`. Several config files require some minor syntax adjustments. The `chunk` module in asim has been expanded since v0.7 and the logging method `chunk.log_df_size` has been replaced by `chunk.log_df`.

https://github.com/RSGInc/bca4abm/issues/97, like for asim and popsim, there's also the question of if/when we should phase out Python2 support entirely. Any strong opinions on this? I think we should consider dropping Python 2 compatibility entirely within the next couple months. Most of our dependencies are going to start breaking any time now, and it we could facilitate a smooth-ish transition to Python 3 for asim/popsim/bca users.